### PR TITLE
🚑 amd環境でも動くように修正

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -1,25 +1,9 @@
-FROM alpine:latest
-
-ARG GOLANG_VERSION=1.21.4
-
-#we need the go version installed from apk to bootstrap the custom version built from source
-RUN apk update && apk add git go gcc bash musl-dev openssl-dev ca-certificates && update-ca-certificates
-
-RUN wget https://dl.google.com/go/go$GOLANG_VERSION.src.tar.gz && tar -C /usr/local -xzf go$GOLANG_VERSION.src.tar.gz
-
-RUN cd /usr/local/go/src && ./make.bash
-
-ENV PATH=$PATH:/usr/local/go/bin
-
-RUN rm go$GOLANG_VERSION.src.tar.gz
+FROM golang:1.21.4-alpine
 
 # air install
 RUN go install github.com/cosmtrek/air@latest
 
 RUN echo "alias air='$(go env GOPATH)/bin/air'" >> /root/.bashrc
-
-#we delete the apk installed version to avoid conflict
-RUN apk del go
 
 # nodejs install
 RUN apk add nodejs npm

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "golang.go",
     "jinliming2.vscode-go-template",
     "esbenp.prettier-vscode",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "ms-azuretools.vscode-docker",
   ]
 }


### PR DESCRIPTION
プレーンなalpineにでgoとnodejsを入れたかったけどamdで動かし方わからなくめんどくさかったのでalpineベースのgolangのイメージにnodejsを入れるようにした